### PR TITLE
Add Multi-Architecture Docker Build Support

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -7,11 +7,14 @@ jobs:
     steps:
       - name: checkout the repo
         uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: build the docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
           tags: aveshadev/gateway-certs-generator:latest
           push: false
       - name: List images

--- a/.github/workflows/docker-push.yaml
+++ b/.github/workflows/docker-push.yaml
@@ -1,0 +1,40 @@
+name: push-image
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Docker image tag'
+        required: true
+        default: 'latest'
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            aveshadev/gateway-certs-generator:${{ github.event.inputs.image_tag }}
+            aveshadev/gateway-certs-generator:latest
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: List images
+        run: docker image ls 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ helm repo update
 
 To download the latest docker image for gateway-certs-generator, click [here](https://hub.docker.com/r/aveshasystems/gateway-certs-generator).
 
+The gateway-certs-generator supports multi-architecture builds for both `linux/amd64` and `linux/arm64` platforms.
+
 1. Clone the latest version of gateway-certs-generator from  the `master` branch.
 
    ```console
@@ -46,12 +48,24 @@ To download the latest docker image for gateway-certs-generator, click [here](ht
    cd gateway-certs-generator
    ```
 
-2. Modify the image name variable `IMG` in the [`Makefile`](Makefile) to change the docker tag to be built.
-   The default image is set as `IMG ?= aveshasystems/gateway-certs-generator:latest`. Modify as needed.
+2. Build multi-architecture images using the Makefile:
 
    ```console
+   # Build for both amd64 and arm64
    make docker-build
+   
+   # Push multi-architecture images to registry
+   make docker-push
    ```
+
+3. Test multi-architecture builds locally:
+
+   ```console
+   ./test-multiarch.sh
+   ```
+
+4. Modify the image name variable `IMG` in the [`Makefile`](Makefile) to change the docker tag to be built.
+   The default image is set as `IMG ?= aveshasystems/gateway-certs-generator:latest`. Modify as needed.
 ### Run Local Image on Kind Cluster
 
 1. Load the gateway-certs-generator image into your kind cluster ([kind](https://kind.sigs.k8s.io/docs/user/quick-start/#loading-an-image-into-your-cluster)).


### PR DESCRIPTION
fixes: #55 

Improvements:

Dockerfile
- Added ARG TARGETOS and ARG TARGETARCH build arguments for cross-compilation
- Modified Go build command to use platform-specific compilation: CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH}

GitHub Actions Workflow
- Updated .github/workflows/docker-build.yaml to enable Docker Buildx for multi-architecture builds
- Added docker/setup-buildx-action@v3 and updated docker/build-push-action to v5
- Added platforms: linux/amd64,linux/arm64 for cross-platform builds

Makefile
- Enhanced existing docker-build and docker-push targets to support multi-architecture builds
- Added --platform linux/amd64,linux/arm64 specification to build commands

Documentation
- Updated README.md with multi-architecture support documentation and build instructions